### PR TITLE
Comp7 use the bits

### DIFF
--- a/board.txt
+++ b/board.txt
@@ -11,9 +11,9 @@ comp2 - Create Connection Class                                                 
     (4) Write / Update unit tests                                                   x
     (5) Write documentation                                                         x
 
-comp3 - Create Bit/BitStream classes
+comp3 - Create Bit/BitStream classes                                                x
     (1) Implement Bit class                                                         x
-    (2) Refactor code to use Bit class instead of int DEFER THIS TO comp5
+    (2) Refactor code to use Bit class instead of int DEFER THIS TO comp5           x
     (3) Implement BitString class                                                   x
     (4) Update unit tests                                                           x
     (5) Write documentation                                                         x
@@ -24,7 +24,7 @@ comp4 - Create hybrid gate classes: xor, nor, nand, nxor, ...                   
     (3) Add/update unit tests                                                       x
     (4) Write documentation DEFER THIS TO comp5                                     x
 
-comp5 - Refactor LogicGate class
+comp5 - Refactor LogicGate class                                                    x
     (1) Delete BinaryGate/UnaryGate modules                                         x
     (2) Make LogicGate an abstract base class interface                             x
     (3) Make other gate classes inherit from LogicGate interface                    x
@@ -33,7 +33,7 @@ comp5 - Refactor LogicGate class
     (4.2) Implement new LogicGate class per discussion                              x
     (4.3) Implement IConnection interface                                           x
     (4.4) Update Connection class                                                   x
-    (5) Make gate classes and connections use Bits DEFER THIS TO comp7
+    (5) Make gate classes and connections use Bits DEFER THIS TO comp7              x
     (6) Update unt tests                                                            x
     (7) Write/update documentation                                                  x
 
@@ -44,11 +44,11 @@ comp6 - Refactor compound gates                                                 
     (5) Update unit tests                                                           x
     (6) Update docs                                                                 x
 
-comp7 - Refactor to make use of Bits
+comp7 - Refactor to make use of Bits                                                x
     (1) Create bit/bit string interface.                                            x
     (2) Make gate classes and connections use Bits                                  x
     (3) Update unit tests                                                           x
-    (4) Update docs
+    (4) Update docs                                                                 x
 
 comp8 - Create Branch class in Connection
     (1) Create Branch class that follows IConnection interface

--- a/board.txt
+++ b/board.txt
@@ -45,7 +45,7 @@ comp6 - Refactor compound gates                                                 
     (6) Update docs                                                                 x
 
 comp7 - Refactor to make use of Bits
-    (1) Create bit/bit string interface.
+    (1) Create bit/bit string interface.                                            x
     (2) Make gate classes and connections use Bits
     (3) Update unit tests
     (4) Update docs

--- a/board.txt
+++ b/board.txt
@@ -46,8 +46,8 @@ comp6 - Refactor compound gates                                                 
 
 comp7 - Refactor to make use of Bits
     (1) Create bit/bit string interface.                                            x
-    (2) Make gate classes and connections use Bits
-    (3) Update unit tests
+    (2) Make gate classes and connections use Bits                                  x
+    (3) Update unit tests                                                           x
     (4) Update docs
 
 comp8 - Create Branch class in Connection

--- a/board.txt
+++ b/board.txt
@@ -45,9 +45,10 @@ comp6 - Refactor compound gates                                                 
     (6) Update docs                                                                 x
 
 comp7 - Refactor to make use of Bits
-    (1) Make gate classes and connections use Bits
-    (2) Update unit tests
-    (3) Update docs
+    (1) Create bit/bit string interface.
+    (2) Make gate classes and connections use Bits
+    (3) Update unit tests
+    (4) Update docs
 
 comp8 - Create Branch class in Connection
     (1) Create Branch class that follows IConnection interface

--- a/src/Computer/Bit/abc.py
+++ b/src/Computer/Bit/abc.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 import enum
 from typing import TypeVar
@@ -13,6 +15,26 @@ class IBit(metaclass=abc.ABCMeta):
 
     @abc.abstractclassmethod
     def __init__(self, value: E):
+        """Constructor..."""
+
+        ...
+
+    @abc.abstractclassmethod
+    def and_op(self, other: IBit) -> IBit:
+        """This implements the `'and'` operation."""
+
+        ...
+
+    @abc.abstractclassmethod
+    def not_op(self) -> IBit:
+        """This implements the `'not'` operation."""
+
+        ...
+
+    @abc.abstractclassmethod
+    def or_op(self, other: IBit) -> IBit:
+        """This implements the `'or'` operation."""
+
         ...
 
 

--- a/src/Computer/Bit/abc.py
+++ b/src/Computer/Bit/abc.py
@@ -1,0 +1,52 @@
+import abc
+import enum
+from typing import TypeVar
+
+E = TypeVar("E", bound=enum.Enum)
+# This is to represent an arbitrary enumeration type.
+
+class IBit(metaclass=abc.ABCMeta):
+    
+    """
+    This implements a single bit to be passed around.
+    """
+
+    @abc.abstractclassmethod
+    def __init__(self, value: E):
+        ...
+
+
+class IBitString(metaclass=abc.ABCMeta):
+
+    """
+    This implements a deque data structure holding `Bit` instances.
+    """
+
+    @abc.abstractclassmethod
+    def __init__(self, max_length: int):
+        """Constructor..."""
+        ...
+
+    @abc.abstractclassmethod
+    def pop_left(self) -> IBit:
+        """Pop off the left-most bit."""
+
+        ...
+
+    @abc.abstractclassmethod
+    def pop_right(self) -> IBit:
+        """Pop off the right-most bit."""
+
+        ...
+
+    @abc.abstractclassmethod
+    def push_left(self) -> IBit:
+        """Push a bit to the left side of the deque."""
+
+        ...
+
+    @abc.abstractclassmethod
+    def push_right(self) -> IBit:
+        """Push a bit to the right side of the deque."""
+
+        ...

--- a/src/Computer/Bit/abc.py
+++ b/src/Computer/Bit/abc.py
@@ -7,8 +7,9 @@ from typing import TypeVar
 E = TypeVar("E", bound=enum.Enum)
 # This is to represent an arbitrary enumeration type.
 
+
 class IBit(metaclass=abc.ABCMeta):
-    
+
     """
     This implements a single bit to be passed around.
     """

--- a/src/Computer/Bit/bit.py
+++ b/src/Computer/Bit/bit.py
@@ -1,6 +1,6 @@
 import enum
 from typing import Union
-from Computer.LogicCircuit.abc import IBit
+from Computer.Bit.abc import IBit
 
 BitValueType = Union[int, bool, str]
 

--- a/src/Computer/Bit/bit.py
+++ b/src/Computer/Bit/bit.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import enum
 from typing import Union
+
 from Computer.Bit.abc import IBit
 
 BitValueType = Union[int, bool, str]
@@ -52,7 +53,7 @@ class Bit(IBit):
         Type:
             BitValue
         """
-        
+
     def __eq__(self, other: Bit) -> bool:
         """
         Overrides Python's `'=='` operator: checks if two bits are the same.
@@ -108,43 +109,43 @@ class Bit(IBit):
                 raise BitError(f"Entered an unknown value: {value}!")
         except (ValueError, TypeError):
             raise BitError("Entered something that cannot be handled!")
-        
+
     def and_op(self, other: Bit) -> Bit:
         """
         This implements a custom `'and'` operation: returns an `'ON'` bit only if both
         the input bits are `'ON'`.
-        
+
         Args:
             other:
                 ...
-                
+
         Returns:
             ret:
                 ...
         """
 
         return Bit(self._value.value and other._value.value)
-    
+
     def not_op(self) -> Bit:
         """
         This implements a custom `'not'` operation: reverses the current bit.
-                
+
         Returns:
             ret:
                 ...
         """
 
         return Bit(not self._value.value)
-    
+
     def or_op(self, other: Bit) -> Bit:
         """
         This implements a custom `'or'` operation: returns an `'OFF'` bit only if both
         the input bits are `'OFF'`.
-        
+
         Args:
             other:
                 ...
-                
+
         Returns:
             ret:
                 ...

--- a/src/Computer/Bit/bit.py
+++ b/src/Computer/Bit/bit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import enum
 from typing import Union
 from Computer.Bit.abc import IBit
@@ -50,30 +52,21 @@ class Bit(IBit):
         Type:
             BitValue
         """
-
-    def __bool__(self) -> bool:
+        
+    def __eq__(self, other: Bit) -> bool:
         """
-        This overrides Python's built-in `bool` function: it will convert the bit to
-        either `'True'` or `'False'` depending on `_value`.
+        Overrides Python's `'=='` operator: checks if two bits are the same.
 
-        Example:
-            ```python
-            >>> bit = Bit(0)
-            >>> bool(bit)
-            False
-            >>> bit = Bit(1)
-            >>> bool(bit)
-            True
-            ```
+        Args:
+            other:
+                ...
 
         Returns:
             flag:
                 ...
         """
-        if self._value == BitValue.OFF:
-            return False
-        elif self._value == BitValue.ON:
-            return True
+
+        return self._value == other._value
 
     def __str__(self) -> str:
         """A string representation of the bit."""
@@ -115,3 +108,46 @@ class Bit(IBit):
                 raise BitError(f"Entered an unknown value: {value}!")
         except (ValueError, TypeError):
             raise BitError("Entered something that cannot be handled!")
+        
+    def and_op(self, other: Bit) -> Bit:
+        """
+        This implements a custom `'and'` operation: returns an `'ON'` bit only if both
+        the input bits are `'ON'`.
+        
+        Args:
+            other:
+                ...
+                
+        Returns:
+            ret:
+                ...
+        """
+
+        return Bit(self._value.value and other._value.value)
+    
+    def not_op(self) -> Bit:
+        """
+        This implements a custom `'not'` operation: reverses the current bit.
+                
+        Returns:
+            ret:
+                ...
+        """
+
+        return Bit(not self._value.value)
+    
+    def or_op(self, other: Bit) -> Bit:
+        """
+        This implements a custom `'or'` operation: returns an `'OFF'` bit only if both
+        the input bits are `'OFF'`.
+        
+        Args:
+            other:
+                ...
+                
+        Returns:
+            ret:
+                ...
+        """
+
+        return Bit(self._value.value or other._value.value)

--- a/src/Computer/Bit/bit.py
+++ b/src/Computer/Bit/bit.py
@@ -1,5 +1,6 @@
 import enum
 from typing import Union
+from Computer.LogicCircuit.abc import IBit
 
 BitValueType = Union[int, bool, str]
 
@@ -23,7 +24,7 @@ class BitError(Exception):
     ...
 
 
-class Bit:
+class Bit(IBit):
 
     """
     This implements a bit class. This ensures that the user doesn't send bad data

--- a/src/Computer/Bit/bit_string.py
+++ b/src/Computer/Bit/bit_string.py
@@ -1,9 +1,10 @@
 from typing import List
 
 from .bit import Bit, BitError
+from Computer.LogicCircuit.abc import IBitString
 
 
-class BitString:
+class BitString(IBitString):
 
     """
     This will implement a string of bits. This will make it easier to manipulate and

--- a/src/Computer/Bit/bit_string.py
+++ b/src/Computer/Bit/bit_string.py
@@ -1,7 +1,8 @@
 from typing import List
 
-from .bit import Bit, BitError
 from Computer.Bit.abc import IBitString
+
+from .bit import Bit, BitError
 
 
 class BitString(IBitString):

--- a/src/Computer/Bit/bit_string.py
+++ b/src/Computer/Bit/bit_string.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from .bit import Bit, BitError
-from Computer.LogicCircuit.abc import IBitString
+from Computer.Bit.abc import IBitString
 
 
 class BitString(IBitString):

--- a/src/Computer/LogicCircuit/Connection/connection.py
+++ b/src/Computer/LogicCircuit/Connection/connection.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Optional
 
-from Computer.LogicCircuit.abc import IConnection
 from Computer.Bit import Bit
+from Computer.LogicCircuit.abc import IConnection
 
 if TYPE_CHECKING:
     from Computer.LogicCircuit.LogicGate import LogicGate

--- a/src/Computer/LogicCircuit/Connection/connection.py
+++ b/src/Computer/LogicCircuit/Connection/connection.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Optional
 
 from Computer.LogicCircuit.abc import IConnection
+from Computer.Bit import Bit
 
 if TYPE_CHECKING:
     from Computer.LogicCircuit.LogicGate import LogicGate
@@ -47,7 +48,7 @@ class Connection(IConnection):
             Optional[LogicGate]
         """
 
-    def feed(self) -> int:
+    def feed(self) -> Bit:
         """
         This is the primary method of this class. It will check to see if the input has
         been set, and will try to get information from it. If it is a `LogicGate`

--- a/src/Computer/LogicCircuit/LogicGate/logic_gate.py
+++ b/src/Computer/LogicCircuit/LogicGate/logic_gate.py
@@ -1,9 +1,9 @@
 import enum
 from typing import List, Optional, Union, cast
 
+from Computer.Bit import Bit
 from Computer.LogicCircuit.abc import ILogicGate
 from Computer.LogicCircuit.Connection import Connection
-from Computer.Bit import Bit
 
 PIN = Union[Bit, "Connection"]
 # This represents everything that a pin can be connected to.

--- a/src/Computer/LogicCircuit/abc.py
+++ b/src/Computer/LogicCircuit/abc.py
@@ -38,7 +38,7 @@ class IConnection(metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractclassmethod
-    def feed(self) -> int:
+    def feed(self) -> IBit:
         """This gets the information from the input and returns it."""
 
         ...

--- a/src/Computer/LogicCircuit/abc.py
+++ b/src/Computer/LogicCircuit/abc.py
@@ -11,6 +11,53 @@ E = TypeVar("E", bound=enum.Enum)
 # This is to represent an arbitrary enumeration type.
 
 
+class IBit(metaclass=abc.ABCMeta):
+    
+    """
+    This implements a single bit to be passed around.
+    """
+
+    @abc.abstractclassmethod
+    def __init__(self, value: E):
+        ...
+
+
+class IBitString(metaclass=abc.ABCMeta):
+
+    """
+    This implements a deque data structure holding `Bit` instances.
+    """
+
+    @abc.abstractclassmethod
+    def __init__(self, max_length: int):
+        """Constructor..."""
+        ...
+
+    @abc.abstractclassmethod
+    def pop_left(self) -> IBit:
+        """Pop off the left-most bit."""
+
+        ...
+
+    @abc.abstractclassmethod
+    def pop_right(self) -> IBit:
+        """Pop off the right-most bit."""
+
+        ...
+
+    @abc.abstractclassmethod
+    def push_left(self) -> IBit:
+        """Push a bit to the left side of the deque."""
+
+        ...
+
+    @abc.abstractclassmethod
+    def push_right(self) -> IBit:
+        """Push a bit to the right side of the deque."""
+
+        ...
+
+
 class ICompoundFactory(metaclass=abc.ABCMeta):
     @abc.abstractclassmethod
     def __init__(self, type: Optional[str] = None):

--- a/src/Computer/LogicCircuit/abc.py
+++ b/src/Computer/LogicCircuit/abc.py
@@ -11,53 +11,6 @@ E = TypeVar("E", bound=enum.Enum)
 # This is to represent an arbitrary enumeration type.
 
 
-class IBit(metaclass=abc.ABCMeta):
-    
-    """
-    This implements a single bit to be passed around.
-    """
-
-    @abc.abstractclassmethod
-    def __init__(self, value: E):
-        ...
-
-
-class IBitString(metaclass=abc.ABCMeta):
-
-    """
-    This implements a deque data structure holding `Bit` instances.
-    """
-
-    @abc.abstractclassmethod
-    def __init__(self, max_length: int):
-        """Constructor..."""
-        ...
-
-    @abc.abstractclassmethod
-    def pop_left(self) -> IBit:
-        """Pop off the left-most bit."""
-
-        ...
-
-    @abc.abstractclassmethod
-    def pop_right(self) -> IBit:
-        """Pop off the right-most bit."""
-
-        ...
-
-    @abc.abstractclassmethod
-    def push_left(self) -> IBit:
-        """Push a bit to the left side of the deque."""
-
-        ...
-
-    @abc.abstractclassmethod
-    def push_right(self) -> IBit:
-        """Push a bit to the right side of the deque."""
-
-        ...
-
-
 class ICompoundFactory(metaclass=abc.ABCMeta):
     @abc.abstractclassmethod
     def __init__(self, type: Optional[str] = None):

--- a/src/Computer/LogicCircuit/abc.py
+++ b/src/Computer/LogicCircuit/abc.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import abc
 import enum
-from Computer.Bit.abc import IBit
 from typing import Dict, Optional, TypeVar
+
+from Computer.Bit.abc import IBit
 
 T = TypeVar("T")
 # This is to represent arbitrary devices.
@@ -22,7 +23,7 @@ class ICompoundFactory(metaclass=abc.ABCMeta):
     @abc.abstractclassmethod
     def create(self) -> Dict[str, T]:
         """This creates the manifest."""
-        
+
         ...
 
 

--- a/src/Computer/LogicCircuit/abc.py
+++ b/src/Computer/LogicCircuit/abc.py
@@ -21,6 +21,8 @@ class ICompoundFactory(metaclass=abc.ABCMeta):
 
     @abc.abstractclassmethod
     def create(self) -> Dict[str, T]:
+        """This creates the manifest."""
+        
         ...
 
 

--- a/src/Computer/LogicCircuit/abc.py
+++ b/src/Computer/LogicCircuit/abc.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import enum
+from Computer.Bit.abc import IBit
 from typing import Dict, Optional, TypeVar
 
 T = TypeVar("T")
@@ -88,7 +89,7 @@ class ILogicGate(metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractclassmethod
-    def get_output_pin(self) -> int:
+    def get_output_pin(self) -> IBit:
         """This gets the output of performing the logic on the input(s)."""
 
         ...
@@ -112,7 +113,7 @@ class ILogicGate(metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractclassmethod
-    def set_input_pin(self, value: int | IConnection = 0, pin: int = 0) -> None:
+    def set_input_pin(self, value: IBit | IConnection = 0, pin: int = 0) -> None:
         """This sets the input pin."""
 
         ...

--- a/src/Computer/LogicCircuit/compound_gate.py
+++ b/src/Computer/LogicCircuit/compound_gate.py
@@ -216,10 +216,7 @@ class CompoundGate(ILogicGate):
             reset_inputs()
             reset_output()
 
-    def set_input_pin(
-        self, value: Bit | Connection = Bit(0), pin: int = 0
-    ) -> None:
-        
+    def set_input_pin(self, value: Bit | Connection = Bit(0), pin: int = 0) -> None:
         """
         This method will set the input pins of the input gates using
         [`set_input_pin`][Computer.LogicCircuit.LogicGate]. It can either be directly

--- a/src/Computer/LogicCircuit/compound_gate.py
+++ b/src/Computer/LogicCircuit/compound_gate.py
@@ -1,15 +1,14 @@
 import enum
 from typing import Dict, Optional, Union
 
+from Computer.Bit import Bit
 from Computer.LogicCircuit.abc import ILogicGate
 from Computer.LogicCircuit.compound_factory import CompoundFactory
 from Computer.LogicCircuit.Connection import Connection
 from Computer.LogicCircuit.LogicGate import LogicGate
 
-PIN = Union[int, "Connection"]
+PIN = Union[Bit, "Connection"]
 # This represents everything that a pin can be connected to.
-# TODO: replace `int` with `Bit` when ready, since bits will be passed around via the
-# `Bit` class rather than integers.
 
 STUFF = Union[LogicGate, Connection]
 # This is a short-hand for the two types of devices used to build the compound gates.
@@ -123,7 +122,7 @@ class CompoundGate(ILogicGate):
 
         return self._type
 
-    def get_output_pin(self):
+    def get_output_pin(self) -> Bit:
         """
         This will be the primary method called by the user. It will call the output
         gate's [`get_output_pin`][Computer.LogicCircuit.LogicGate] method and return the
@@ -132,8 +131,6 @@ class CompoundGate(ILogicGate):
         NOTE:
             This method is marked public and can be called by the user, though it is
             more likely to be called by other objects, such as `Connection`.
-
-        TODO: update when `Bit` can be passed around.
 
         Returns:
             result:
@@ -219,7 +216,10 @@ class CompoundGate(ILogicGate):
             reset_inputs()
             reset_output()
 
-    def set_input_pin(self, value: int | Connection = 0, pin: int = 0) -> None:
+    def set_input_pin(
+        self, value: Bit | Connection = Bit(0), pin: int = 0
+    ) -> None:
+        
         """
         This method will set the input pins of the input gates using
         [`set_input_pin`][Computer.LogicCircuit.LogicGate]. It can either be directly

--- a/test/Bit/test_bit.py
+++ b/test/Bit/test_bit.py
@@ -30,6 +30,7 @@ def test_bit_creation_error_bad_input():
 
     assert exc.value.args[0] == "Entered something that cannot be handled!"
 
+
 @pytest.mark.parametrize(
     ("bits", "res"),
     [

--- a/test/Bit/test_bit.py
+++ b/test/Bit/test_bit.py
@@ -7,17 +7,17 @@ from Computer.Bit.bit import BitError
 @pytest.mark.parametrize(
     "config",
     [
-        dict(value=0, result=False),
-        dict(value=1, result=True),
-        dict(value="0", result=False),
-        dict(value="1", result=True),
-        dict(value=False, result=False),
-        dict(value=True, result=True),
+        dict(value=0, result=Bit(0)),
+        dict(value=1, result=Bit(1)),
+        dict(value="0", result=Bit(0)),
+        dict(value="1", result=Bit(1)),
+        dict(value=False, result=Bit(0)),
+        dict(value=True, result=Bit(1)),
     ],
 )
 def test_bit_creation(config):
     bit = Bit(config["value"])
-    assert bool(bit) == config["result"]
+    assert bit == config["result"]
 
 
 def test_bit_creation_error_bad_input():
@@ -29,3 +29,29 @@ def test_bit_creation_error_bad_input():
         Bit(["1"])
 
     assert exc.value.args[0] == "Entered something that cannot be handled!"
+
+@pytest.mark.parametrize(
+    ("bits", "res"),
+    [
+        (
+            [Bit(0), Bit(0)],
+            [Bit(0), Bit(1), Bit(0)],
+        ),
+        (
+            [Bit(0), Bit(1)],
+            [Bit(0), Bit(1), Bit(1)],
+        ),
+        (
+            [Bit(1), Bit(0)],
+            [Bit(0), Bit(0), Bit(1)],
+        ),
+        (
+            [Bit(1), Bit(1)],
+            [Bit(1), Bit(0), Bit(1)],
+        ),
+    ],
+)
+def test_bit_op(bits, res):
+    assert bits[0].and_op(bits[1]) == res[0]
+    assert bits[0].not_op() == res[1]
+    assert bits[0].or_op(bits[1]) == res[2]

--- a/test/Bit/test_bit_string.py
+++ b/test/Bit/test_bit_string.py
@@ -28,7 +28,7 @@ def test_bit_string_iter(bits):
     res = [0, 1, 0]
     for bit0, bit1 in zip(bits, res):
         assert isinstance(bit0, Bit)
-        assert int(bool(bit0)) == bit1
+        assert bit0 == Bit(bit1)
 
 
 def test_bit_string_length(bits):
@@ -49,11 +49,11 @@ def test_bit_string_push(bits, config):
         assert len(bits) == 4
         assert len(bits) < bits.max_length
         for bit0, bit1 in zip(bits._bits, config["res"]):
-            assert int(bool(bit0)) == bit1
+            assert bit0 == Bit(bit1)
 
     elif config["dir"] == "right":
         bits.push_right(Bit(config["value"]))
         assert len(bits) == 4
         assert len(bits) < bits.max_length
         for bit0, bit1 in zip(bits._bits, config["res"]):
-            assert int(bool(bit0)) == bit1
+            assert bit0 == Bit(bit1)

--- a/test/LogicCircuit/Connection/test_connection.py
+++ b/test/LogicCircuit/Connection/test_connection.py
@@ -3,14 +3,15 @@ import pytest
 from Computer.LogicCircuit.Connection import Connection
 from Computer.LogicCircuit.Connection.connection import ConnectionError
 from Computer.LogicCircuit.LogicGate import LogicGate, LogicType
+from Computer.Bit import Bit
 
 
 @pytest.fixture
 def gate():
     gate = LogicGate(LogicType.AND)
     gate.name = "foo"
-    gate.set_input_pin(value=0, pin=0)
-    gate.set_input_pin(value=1, pin=1)
+    gate.set_input_pin(value=Bit(0), pin=0)
+    gate.set_input_pin(value=Bit(1), pin=1)
     return gate
 
 
@@ -33,8 +34,8 @@ def test_connection_feed_error_no_ouput():
 def test_connection_feed(gate):
     conn = Connection()
     conn._input_connection = gate
-    ret: int = conn.feed()
-    assert ret == 0
+    ret: Bit = conn.feed()
+    assert ret == Bit(0)
 
 
 def test_has_input_connection_set(gate):

--- a/test/LogicCircuit/Connection/test_connection.py
+++ b/test/LogicCircuit/Connection/test_connection.py
@@ -1,9 +1,9 @@
 import pytest
 
+from Computer.Bit import Bit
 from Computer.LogicCircuit.Connection import Connection
 from Computer.LogicCircuit.Connection.connection import ConnectionError
 from Computer.LogicCircuit.LogicGate import LogicGate, LogicType
-from Computer.Bit import Bit
 
 
 @pytest.fixture

--- a/test/LogicCircuit/LogicGate/test_logic_gate.py
+++ b/test/LogicCircuit/LogicGate/test_logic_gate.py
@@ -1,12 +1,12 @@
 import collections
 from typing import List
-from unittest import mock
 
 import pytest
 
 from Computer.LogicCircuit.Connection import Connection
 from Computer.LogicCircuit.LogicGate import LogicGate, LogicType
 from Computer.LogicCircuit.LogicGate.logic_gate import LogicGateError
+from Computer.Bit import Bit
 
 
 class TestLogicGates:
@@ -18,9 +18,14 @@ class TestLogicGates:
 
     def get_combs(self, num: int) -> List[List[int]]:
         if num == 1:
-            return [[1], [0]]
+            return [[Bit(1)], [Bit(0)]]
         elif num == 2:
-            return [[1, 1], [1, 0], [0, 1], [0, 0]]
+            return [
+                [Bit(1), Bit(1)],
+                [Bit(1), Bit(0)],
+                [Bit(0), Bit(1)],
+                [Bit(0), Bit(0)]
+            ]
 
     def test_logic_gate_init_error_no_type(self):
         with pytest.raises(LogicGateError) as exc:
@@ -63,13 +68,6 @@ class TestLogicGates:
         assert gate.name == config.name + "_1"
         assert gate.type == config.gtype
 
-    def test_logic_gate__sanitize_input(self):
-        gate = LogicGate(type=LogicType.AND)
-        with pytest.raises(AssertionError) as exc:
-            gate._sanitize_input(2)
-
-        assert exc.value.args[0] == "2 is not a valid input!"
-
     def test_logic_gate_get_output_pin_input_not_set(self):
         gate = LogicGate(type=LogicType.NOT)
         with pytest.raises(LogicGateError) as exc:
@@ -85,20 +83,20 @@ class TestLogicGates:
             or_gate,
         ],
     )
-    def test_logic_gate_get_output_pin_ints(self, config):
+    def test_logic_gate_get_output_pin_bits(self, config):
         inputs = self.get_combs(config.num)
         gates = LogicGate(type=config.gtype, name=config.name)
         for inp in inputs:
             gates._input_pins = inp
             ret = gates.get_output_pin()
-            assert isinstance(ret, int)
+            assert isinstance(ret, Bit)
 
             if config.gtype == LogicType.NOT:
-                logic = not inp[0]
+                logic = inp[0].not_op()
             elif config.gtype == LogicType.AND:
-                logic = inp[0] and inp[1]
+                logic = inp[0].and_op(inp[1])
             elif config.gtype == LogicType.OR:
-                logic = inp[0] or inp[1]
+                logic = inp[0].or_op(inp[1])
 
             assert ret == logic
             gates._input_pins = [None] * config.num
@@ -126,8 +124,8 @@ class TestLogicGates:
 
     def test_logic_gate_reset(self):
         gate = LogicGate(LogicType.AND)
-        gate._input_pins = [0, 1]
-        gate._output_pin = 1
+        gate._input_pins = [Bit(0), Bit(1)]
+        gate._output_pin = Bit(1)
         assert gate.has_input_pin_set(pin=0)
         assert gate.has_input_pin_set(pin=1)
         assert gate.has_output_pin_set()
@@ -136,8 +134,8 @@ class TestLogicGates:
         assert not gate.has_input_pin_set(pin=1)
         assert not gate.has_output_pin_set()
 
-        gate._input_pins = [0, 1]
-        gate._output_pin = 1
+        gate._input_pins = [Bit(0), Bit(1)]
+        gate._output_pin = Bit(1)
         assert gate.has_input_pin_set(pin=0)
         assert gate.has_input_pin_set(pin=1)
         assert gate.has_output_pin_set()
@@ -145,7 +143,7 @@ class TestLogicGates:
         assert not gate.has_input_pin_set(pin=0)
         assert not gate.has_input_pin_set(pin=1)
         assert gate.has_output_pin_set()
-        gate._input_pins = [0, 1]
+        gate._input_pins = [Bit(0), Bit(1)]
         gate.reset(which="output")
         assert gate.has_input_pin_set(pin=0)
         assert gate.has_input_pin_set(pin=1)
@@ -153,18 +151,16 @@ class TestLogicGates:
 
     def test_logic_gate_set_input_pin_error_pin_already_set(self):
         gate = LogicGate(LogicType.AND)
-        gate._input_pins[0] = 1
+        gate._input_pins[0] = Bit(1)
         with pytest.raises(LogicGateError) as exc:
-            gate.set_input_pin(value=0, pin=0)
+            gate.set_input_pin(value=Bit(0), pin=0)
 
         assert exc.value.args[0] == "Input pin 0 has already been set!"
 
-    @mock.patch.object(LogicGate, "_sanitize_input")
-    def test_logic_gate_set_input_pin(self, mock_sanitize):
+    def test_logic_gate_set_input_pin(self):
         gate = LogicGate(LogicType.AND)
-        gate.set_input_pin(value=1, pin=0)
-        assert gate._input_pins[0] == 1
-        mock_sanitize.assert_called_once_with(0)
+        gate.set_input_pin(value=Bit(1), pin=0)
+        assert gate._input_pins[0] == Bit(1)
 
     def test_logic_gate_set_output_pin_error_value_none(self):
         gate = LogicGate(LogicType.AND)

--- a/test/LogicCircuit/LogicGate/test_logic_gate.py
+++ b/test/LogicCircuit/LogicGate/test_logic_gate.py
@@ -3,10 +3,10 @@ from typing import List
 
 import pytest
 
+from Computer.Bit import Bit
 from Computer.LogicCircuit.Connection import Connection
 from Computer.LogicCircuit.LogicGate import LogicGate, LogicType
 from Computer.LogicCircuit.LogicGate.logic_gate import LogicGateError
-from Computer.Bit import Bit
 
 
 class TestLogicGates:
@@ -24,7 +24,7 @@ class TestLogicGates:
                 [Bit(1), Bit(1)],
                 [Bit(1), Bit(0)],
                 [Bit(0), Bit(1)],
-                [Bit(0), Bit(0)]
+                [Bit(0), Bit(0)],
             ]
 
     def test_logic_gate_init_error_no_type(self):

--- a/test/LogicCircuit/test_compound_gate.py
+++ b/test/LogicCircuit/test_compound_gate.py
@@ -3,6 +3,7 @@ from typing import List
 
 import pytest
 
+from Computer.Bit import Bit
 from Computer.LogicCircuit import CompoundGate, CompoundType
 from Computer.LogicCircuit.compound_gate import CompoundGateError
 from Computer.LogicCircuit.Connection import Connection
@@ -17,7 +18,12 @@ class TestCompoundGates:
     xnor_gate = cgate(CompoundType.XNOR, "spam", "xnor")
 
     def get_combs(self) -> List[List[int]]:
-        return [[1, 1], [1, 0], [0, 1], [0, 0]]
+        return [
+            [Bit(1), Bit(1)],
+            [Bit(1), Bit(0)],
+            [Bit(0), Bit(1)],
+            [Bit(0), Bit(0)]
+        ]
 
     def test_compound_gate_init_error_bad_type(self):
         with pytest.raises(CompoundGateError) as exc:
@@ -98,24 +104,22 @@ class TestCompoundGates:
     )
     def test_compound_gate_get_output_pin(self, config):
         inputs = self.get_combs()
-        print(f"{config=}")
         gate = CompoundGate(type=config.gtype, name=config.name)
         for inp in inputs:
-            print(f"{inp=}")
             for g in gate._input_gates:
                 g._input_pins = inp
 
             ret = gate.get_output_pin()
-            assert isinstance(ret, int)
+            assert isinstance(ret, Bit)
 
             if config.gtype == CompoundType.NAND:
-                logic = not (inp[0] and inp[1])
+                logic = inp[0].and_op(inp[1]).not_op()
             elif config.gtype == CompoundType.NOR:
-                logic = not (inp[0] or inp[1])
+                logic = inp[0].or_op(inp[1]).not_op()
             elif config.gtype == CompoundType.XOR:
-                logic = inp[0] != inp[1]
+                logic = Bit(inp[0] != inp[1])
             elif config.gtype == CompoundType.XNOR:
-                logic = inp[0] == inp[1]
+                logic = Bit(inp[0] == inp[1])
 
             assert ret == logic
             for g in gate._input_gates:

--- a/test/LogicCircuit/test_compound_gate.py
+++ b/test/LogicCircuit/test_compound_gate.py
@@ -18,12 +18,7 @@ class TestCompoundGates:
     xnor_gate = cgate(CompoundType.XNOR, "spam", "xnor")
 
     def get_combs(self) -> List[List[int]]:
-        return [
-            [Bit(1), Bit(1)],
-            [Bit(1), Bit(0)],
-            [Bit(0), Bit(1)],
-            [Bit(0), Bit(0)]
-        ]
+        return [[Bit(1), Bit(1)], [Bit(1), Bit(0)], [Bit(0), Bit(1)], [Bit(0), Bit(0)]]
 
     def test_compound_gate_init_error_bad_type(self):
         with pytest.raises(CompoundGateError) as exc:


### PR DESCRIPTION
The last refactor for this go around...
* Created interface for `Bit` and `BitString`
* Removed `__bool__` and implemented `__eq__` and custom `'and'`, `'or'`, and `'not'` operations.
* Updated other classes to pass `Bit` instances only instead of `int`'
    - NOTE: this will need to be updated later to pass `'None'` if nothing was set.
* Updated unit tests and docs.